### PR TITLE
Docs/update gitignore: Added /envs and easydata.wiki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 docs/site/
 easydata.wiki
+envs/
 
 # OSX Junk
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docs/site/
+easydata.wiki
 
 # OSX Junk
 .DS_Store

--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -87,3 +87,6 @@ target/
 
 # Mypy cache
 .mypy_cache/
+
+# environment files
+/envs


### PR DESCRIPTION
Added /envs to prevent packages being tracked in the root development directory and envs/ in the cookiecutter project template.

Added easydata.wiki to prevent template wiki files being tracked.